### PR TITLE
Bugfix to allow hyphen `-` in the custom bucket name

### DIFF
--- a/functions/getTempCOS.ts
+++ b/functions/getTempCOS.ts
@@ -36,7 +36,8 @@ exports.main = async function (ctx: FunctionContext) {
 }
 
 async function getTempUrl(secretId: string, secretKey: string, region: string, bucket: string) {
-  const uid = bucket.split('-')[1]
+  const bucketSegments = bucket.split('-');
+  const uid = bucketSegments[bucketSegments.length - 1];
   const clientConfig = {
     credential: {
       secretId: secretId,


### PR DESCRIPTION
如腾讯云COS要求，Bucket的ID由自定义名称与用户APPID组成，即`{CUSTOM_NAME}-{APPID}`，不应假定自定义名称中不含Hyphen`-`而直接使用`bucket.split('-')[1]`作为`APPID`，应当使用由`-`分隔的最后一段。
By the way，为了这个bug我花了四个小时看小程序IDE和Laf后台的log进行调试。

