### PR TITLE
新增photoRank.wxss中.row .name的宽度设置

### DIFF
--- a/miniprogram/components/photoRank/photoRank.wxss
+++ b/miniprogram/components/photoRank/photoRank.wxss
@@ -105,6 +105,7 @@
 .row .name {
   font-size: 36rpx;
   padding-left: 20rpx;
+  width: 300rpx; /*避免用户名称过长*/
 }
 .row .photo_count {
   font-size: 50rpx;


### PR DESCRIPTION
### 原样式没有宽度限制会导致显示异常，新增宽度限制保持显示占位一致。

![微信图片_20231104194901](https://github.com/sysucats/zhongdamaopu/assets/95154525/dcff03a3-2a4e-439a-bfa4-4393fce53890)
![微信图片_20231104194907](https://github.com/sysucats/zhongdamaopu/assets/95154525/acfd8a2d-32c4-4c77-85d5-21d5b0335cac)
