### PR TITLE
fix: photoRank页面个人信息修改以及一些拼写错误

### DIFF
--- a/miniprogram/components/modifyUserInfo/modifyUserInfo.js
+++ b/miniprogram/components/modifyUserInfo/modifyUserInfo.js
@@ -68,12 +68,18 @@ Component({
         return false;
       }
 
-      if(!this.checkNickName(user.userInfo.nickName)) {
+      if (!await this.checkNickName(user.userInfo.nickName)) {
+        wx.hideLoading();
         return false;
       }
-
+    
       if (!user.userInfo.avatarUrl) {
-        user.userInfo.avatarUrl = defaultAvatarUrl;
+        wx.showToast({
+          title: '请选择头像',
+          icon: 'error',
+        });
+        wx.hideLoading();
+        return false;
       }
 
       user.userInfo.avatarUrl = await this.uploadAvatar(user.userInfo.avatarUrl);
@@ -122,12 +128,14 @@ Component({
       if (!name) {
         wx.showToast({
           title: '请输入昵称',
+          icon: 'error'
         });
         return false;
       }
       if (name.length > 30) {
         wx.showToast({
           title: '昵称太长啦...20字',
+          icon: 'error'
         });
         return false;
       }

--- a/miniprogram/components/modifyUserInfo/modifyUserInfo.wxss
+++ b/miniprogram/components/modifyUserInfo/modifyUserInfo.wxss
@@ -79,8 +79,11 @@ picker, input {
   margin-bottom: 80rpx;
 }
 
+button.primary::after {
+  border: none;
+}
 button.primary {
-  border-radius: 40rpx;
+  border-radius: 100rpx;
   background-color: var(--color-primary);
   color: var(--color-white);
   width: 500rpx;

--- a/miniprogram/components/photoRank/photoRank.js
+++ b/miniprogram/components/photoRank/photoRank.js
@@ -3,6 +3,9 @@ import { formatDate } from "../../utils/utils";
 import { text as text_cfg } from "../../config";
 import { cloud } from "../../utils/cloudAccess";
 
+//  默认头像
+const defaultAvatarUrl = "/pages/public/images/info/default_avatar.png";
+
 // components/photoRank/photoRank.ts
 Component({
   /**
@@ -17,6 +20,7 @@ Component({
    */
   data: {
     text_cfg: text_cfg,
+    defaultAvatarUrl: defaultAvatarUrl,
   },
 
   /**
@@ -27,10 +31,6 @@ Component({
       this.getRank();
       await getPageUserInfo(this);
       await this.getMyRank();
-    },
-
-    async getUInfo() {
-      toSetUserInfo()
     },
   
     async getRank() {
@@ -91,6 +91,16 @@ Component({
           return;
         }
       }
-    }
+    },
+    
+    getUInfo: function() {
+      this.setData({
+      showEdit: true
+      });
+    },
+    onUserInfoUpdated(event) {
+      const { user } = event.detail;
+      this.setData({ user });
+    },
   }
 })

--- a/miniprogram/components/photoRank/photoRank.json
+++ b/miniprogram/components/photoRank/photoRank.json
@@ -1,4 +1,6 @@
 {
   "component": true,
-  "usingComponents": {}
+  "usingComponents": {
+    "modifyUserInfo": "/components/modifyUserInfo/modifyUserInfo"
+  }
 }

--- a/miniprogram/components/photoRank/photoRank.wxml
+++ b/miniprogram/components/photoRank/photoRank.wxml
@@ -12,7 +12,7 @@
     <view class='number {{user.photo_rank && user.photo_rank <= 3? "active": ""}}'>{{user.photo_rank || '---'}}</view>
   </view>
   <view class='text cen my-info'>
-    <image mode='aspectFill' src='{{user.userInfo.avatarUrl}}'></image>
+    <image mode='aspectFill' src='{{user.userInfo.avatarUrl || defaultAvatarUrl}}' bindtap='getUInfo'></image>
     <view class='name'>{{user.nickName}}</view>
   </view>
   <view class='text right'>
@@ -26,10 +26,10 @@
   <view class='row' wx:for='{{ranks}}' wx:key='openid'>
     <view class='rank'>{{item.rank}}</view>
     <view class='avatar'>
-      <image class='avatar' mode='aspectFill' src='{{item.userInfo.avatarUrl}}'></image>
+      <image class='avatar' mode='aspectFill' src='{{item.userInfo.avatarUrl || defaultAvatarUrl}}'></image>
       <image wx:if='{{item.rank<=3}}' class='medal' mode='aspectFill' src='/pages/public/images/info/rank/{{item.rank}}.png'></image>
     </view>
-    <view class='name'>{{item.userInfo.nickName}}</view>
+    <view class='name'>{{item.userInfo.nickName || text_cfg.genealogy.photo_by_unknow_tip}}</view>
     <view class='photo_count {{item.rank<=3? "active": ""}}'>{{item.count}}</view>
   </view>
 </view>
@@ -37,3 +37,6 @@
 <view class='tip'>{{text_cfg.photo_rank.count_tip}}，上次更新时间：{{rankTime}}</view>
 
 <view style='margin-top: 20rpx;'></view>
+
+<!-- 个人信息修改组件 -->
+<modifyUserInfo show="{{showEdit}}" bind:close="closeEdit"></modifyUserInfo>

--- a/miniprogram/pages/info/userInfo/userInfo.js
+++ b/miniprogram/pages/info/userInfo/userInfo.js
@@ -131,16 +131,27 @@ Page({
     if (!user.userInfo) {
       user.userInfo = {};
     }
-    // 判断角色
-    let badgeName = 'VISITOR'; // 默认值
-      if (user.manager > 0) {
-        badgeName = 'MANAGER';
-      } else if (user.role === 1) {
-        badgeName = 'PRO';
-      }
+    
+    // 创建角色映射便于管理和自定义
+    const roleMapping = {                                         // 自定义部分：（感觉可以写入config.js，但就这几个不知道是否有必要）
+      visitor: { displayName: "VISITOR", className: "visitor" },  // displayName: "游客"
+      manager: { displayName: "MANAGER", className: "manager" },  // displayName: "管理员"
+      pro: { displayName: "PRO", className: "pro" }               // displayName: "特邀用户"
+    };
+    
+    let roleKey = 'visitor'; // 默认值
+    if (user.manager > 0) {
+      roleKey = 'manager';
+    } else if (user.role === 1) {
+      roleKey = 'pro';
+    }
+    
+    const badgeInfo = roleMapping[roleKey];
+    
     this.setData({
       user: user,
-      badgeName: badgeName,
+      badgeName: badgeInfo.displayName,
+      badgeClass: badgeInfo.className,
     });
   },
 })

--- a/miniprogram/pages/info/userInfo/userInfo.wxml
+++ b/miniprogram/pages/info/userInfo/userInfo.wxml
@@ -2,9 +2,7 @@
   <view class="user-container">
     <view class="avatar-container">
       <image class="avatar" src="{{user.userInfo.avatarUrl || defaultAvatarUrl}}" mode="aspectFill"></image>
-      <text wx:if="{{showManagerBadge}}" class="manager-badge">MANAGER</text>
-      <text wx:elif="{{showProBadge}}" class="pro-badge">PRO</text>
-      <text class="badge {{badgeName}}-badge">{{badgeName}}</text>
+      <text class="badge {{badgeClass}}-badge">{{badgeName}}</text>
     </view>
     <text class="user-name">{{user.userInfo.nickName}}</text>
   </view>

--- a/miniprogram/pages/info/userInfo/userInfo.wxss
+++ b/miniprogram/pages/info/userInfo/userInfo.wxss
@@ -41,13 +41,13 @@ page {
   border-radius: 10rpx;
   font-size: 20rpx;
 }
-.PRO-badge {
+.pro-badge {
   background-color: #FFD700;
 }
-.MANAGER-badge {
+.manager-badge {
   background-color: var(--color-primary);
 }
-.VISTEOR-badge {
+.visitor-badge {
   background-color: var(--color-gray-max);
 }
 


### PR DESCRIPTION
- photoRank页面点击授权弹出modifyUserInfo组件
- modifyUserInfo组件中昵称为空白时不予保存
- 拼写错误导致的样式渲染bug
![微信图片_20240603171904](https://github.com/sysucats/zhongdamaopu/assets/94786236/6efe9d9c-395a-42d8-b3f2-d905561f829a)

