### PR TITLE
feat: 调整一下喵友圈ui

### DIFF
--- a/miniprogram/components/popup/popup.wxml
+++ b/miniprogram/components/popup/popup.wxml
@@ -1,4 +1,4 @@
-<mask style="z-index: 1;" show="{{show}}" bind:close="hide"></mask>
+<mask style="z-index: 99999;" show="{{show}}" bind:close="hide"></mask>
 <view class="popup-container {{show ? 'show' : ''}}">
   <slot></slot>
 </view>

--- a/miniprogram/components/popup/popup.wxss
+++ b/miniprogram/components/popup/popup.wxss
@@ -6,7 +6,7 @@
   width: 100%;
   border-top-right-radius: 40rpx;
   border-top-left-radius: 40rpx;
-  z-index: 999;
+  z-index: 999999;
   padding: 20rpx 20rpx;
   padding-bottom: max(20rpx, env(safe-area-inset-bottom));
   overflow: hidden;

--- a/miniprogram/pages/followFeed/followFeed.js
+++ b/miniprogram/pages/followFeed/followFeed.js
@@ -17,6 +17,8 @@ import {
   showTab
 } from "../../utils/page";
 
+import api from "../../utils/cloudApi";
+
 // 每次触底加载的数量
 const loadCount = 13;
 // 最多加载几天前的照片
@@ -24,6 +26,9 @@ const maxNDaysAgo = 30;
 
 // 正则表达式：不以 HEIC 为文件后缀的字符串
 const no_heic = /^((?!\.heic$).)*$/i;
+
+// 头像渐变边框
+const { gradientAvatarSvg } = require('./gradientAvatar.svg.js');
 
 Page({
   jsData: {
@@ -35,11 +40,13 @@ Page({
     loadedCount: {
       photo: 0,
       comment: 0,
-    }
+    },
+    updatingFollowCats: false,
   },
   data: {
     feed: [],
     loadnomore: false,
+    currentCatId: null,
   },
 
   /**
@@ -48,6 +55,7 @@ Page({
   async onLoad() {
     await this.loadUser();
     await this.loadFollowCats();
+    await this.loadFollowCatsDetail();
     await this.loadMoreFeed();
     this.setData({
       refreshing: false
@@ -139,7 +147,58 @@ Page({
     };
   },
 
-  async _loadData(coll) {
+  // 加载关注猫列表的详细信息
+  async loadFollowCatsDetail() {
+    const db = await cloud.databaseAsync();
+    const _ = db.command;
+    const { followCats } = this.data;
+  
+    // 加载关注列表，用于顶部展示
+    const followCatsList = await getCatItemMulti(followCats);
+  
+    // 获取当前时间和 maxNDaysAgo 天前的时间
+    const maxCreateDate = getDateWithDiffHours(-1 * maxNDaysAgo * 24);
+  
+    // 每只猫咪最近的照片信息
+    // 并行获取每只猫咪的头像和最近的照片信息
+    const promises = followCatsList.map(async (p) => {
+      p.avatar = await getAvatar(p._id, p.photo_count_best); // 获取猫猫头像
+      p.unfollowed = false; // 默认未取关
+
+      const latestPhoto = (await db.collection("photo")
+        .where({
+          cat_id: p._id,
+          verified: true,
+          photo_id: no_heic,
+          create_date: _.gt(maxCreateDate),
+        })
+        .orderBy("create_date", "desc")
+        .limit(1)
+        .get()).data[0];
+
+      // 记录最近照片的创建时间
+      p.latestPhotoTime = latestPhoto ? latestPhoto.create_date : 0;
+
+      // 动态改变不同状态猫的svg颜色 => 旧动态：#ccc；新动态：#gradient
+      // TODO: 添加动态过渡动画
+      if (latestPhoto && new Date(latestPhoto.create_date) > maxCreateDate) {
+        p.svgImg = gradientAvatarSvg('url(#gradient)');
+      } else {
+        p.svgImg = gradientAvatarSvg('#ccc');
+      }
+
+      return p;
+    });
+    
+    const updatedFollowCatsList = await Promise.all(promises);
+
+    // 按照最近照片时间对关注列表进行降序排序（只考虑照片作为猫动态，人类的留言不予考虑）
+    updatedFollowCatsList.sort((a, b) => b.latestPhotoTime - a.latestPhotoTime);
+    console.log('关注列表', updatedFollowCatsList);
+    this.setData({followCatsList: updatedFollowCatsList});
+  },
+
+  async _loadData(coll, catId = null) {
     let {loadedCount} = this.jsData;
     let {followCats} = this.data;
 
@@ -151,18 +210,24 @@ Page({
     let maxCreateDate = getDateWithDiffHours(-1 * maxNDaysAgo * 24);
     if (coll === 'photo') {
       whereField = {
-        cat_id: _.in(followCats),
         verified: true,
         photo_id: no_heic,
         create_date: _.gt(maxCreateDate),
       }
     } else if (coll === 'comment') {
       whereField = {
-        cat_id: _.in(followCats),
         deleted: _.neq(true),
         needVerify: false,
         create_date: _.gt(maxCreateDate),
-      }
+      };
+    }
+  
+    if (catId) {
+      // 加载指定猫猫的数据
+      whereField.cat_id = catId;
+    } else {
+      // 加载全部数据
+      whereField.cat_id = _.in(followCats);
     }
     let res = (await db.collection(coll)
     .where(whereField)
@@ -172,15 +237,11 @@ Page({
     .get()).data;
     // 填充猫和用户数据
     let openidField = coll === 'photo' ? '_openid' : 'user_openid';
-    var [cat_res] = await Promise.all([
-      getCatItemMulti(res.map(p => p.cat_id)),
-      await fillUserInfo(res, openidField, "userInfo"),
-    ]);
+    await fillUserInfo(res, openidField, "userInfo");
     for (let i = 0; i < res.length; i++) {
       var p = res[i];
-      p.cat = cat_res[i];
-      p.cat.avatar = await getAvatar(p.cat._id, p.cat.photo_count_best)
-      p.datetime = formatDate(new Date(p.create_date), "yyyy-MM-dd hh:mm")
+      p.cat = this.data.followCatsList.find(cat => cat._id === p.cat_id); // 用followCatsList里的数据填充cat字段
+      p.datetime = this.formatDateTime(new Date(p.create_date));  // 另一种格式化时间的方案，或许对动态展示更友好
       if (coll == 'comment') {
         // 便签旋转
         p.rotate = randomInt(-5, 5);
@@ -197,6 +258,39 @@ Page({
     return res;
   },
 
+  // 格式化时间
+  // 1. 如果是当天：xx小时前；
+  // 2. 如果是一周内：xx天前；
+  // 3. 超过一周：1周前；
+  // 4. 超过两周：xx月xx日；
+  // 5. 超过一年：xxxx年xx月xx日（对于目前来说不需要，先写了）。
+  formatDateTime(date) {
+    const now = new Date();
+    const diff = now - date;
+    const secondsDiff = Math.floor(diff / 1000);
+    const minutesDiff = Math.floor(diff / (1000 * 60));
+    const hoursDiff = Math.floor(diff / (1000 * 60 * 60));
+    const daysDiff = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const weeksDiff = Math.floor(daysDiff / 7);
+    const yearsDiff = now.getFullYear() - date.getFullYear();
+  
+    const formatMap = [    
+      [() => secondsDiff < 60, '刚刚'],
+      [() => minutesDiff < 60, `${minutesDiff}分钟前`],
+      [() => hoursDiff < 24, `${hoursDiff}小时前`],
+      [() => daysDiff < 7, `${daysDiff}天前`],
+      [() => weeksDiff < 2, '1周前'],
+      [() => yearsDiff < 1, `${date.getMonth() + 1}月${date.getDate()}日`],
+      [() => true, `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`],
+    ];
+  
+    for (const [condition, format] of formatMap) {
+      if (condition()) {
+        return format;
+      }
+    }
+  },
+
   // 加载更多的猫猫照片和留言
   async loadMoreFeed() {
     if (this.jsData.loadingLock) {
@@ -209,7 +303,28 @@ Page({
     let {waitingList, loadedCount} = this.jsData;
 
     let loadnomore = true;
-    
+
+    const { currentCatId } = this.data;
+    if (currentCatId) {
+      // 加载指定猫猫的数据
+      if (waitingList.photo.length <= loadCount) {
+        let res = await this._loadData("photo", currentCatId);
+        if (res.length === loadCount + 1) {
+          loadnomore = false;
+        }
+        waitingList.photo.push(...res);
+        loadedCount.photo += res.length;
+      }
+      if (waitingList.comment.length <= loadCount) {
+        let res = await this._loadData("comment", currentCatId);
+        if (res.length === loadCount + 1) {
+          loadnomore = false;
+        }
+        waitingList.comment.push(...res);
+        loadedCount.comment += res.length;
+      }
+    } else {
+    // 加载全部数据
     if (waitingList.photo.length <= loadCount) {
       let res = await this._loadData("photo");
       if (res.length === loadCount + 1) {
@@ -226,6 +341,7 @@ Page({
       }
       waitingList.comment.push(...res);
       loadedCount.comment += res.length;
+    }
     }
     console.log(waitingList, loadnomore);
     this.setData({loadnomore});
@@ -271,27 +387,41 @@ Page({
     console.log(res);
 
     let { feed } = this.data;
+    const timeInterval = 5 * 60 * 1000; // 5分钟内的动态合并
     for (let i = 0; i < res.length; i++) {
       const item = res[i];
+      
+      // 当展示该猫猫的动态时进行取关再刷新，此时关注列表不包含此猫，但feed数组中仍然存在该猫动态数据，因此当 item.cat 为 undefined，跳过该条数据
+      if (!item.cat) {
+        continue;
+      }
       let newBlock = {
         dtype: item.dtype,
         cat: item.cat,
         items: [item]
       };
       // 几种情况会新增一个block：
-      // 1. feed流是空的；2. 上一个是不同类型；3. 上一组不是同一只猫；4. 上一个照片组已经有9张；5. 上一个留言组已经有3张
+      // 1. feed流是空的；2. 上一个是不同类型；3. 上一组不是同一只猫；4. 上一个照片组已经有9张；5. 上一个留言组已经有3张；6. 按用户分组，时间间隔超过5分钟
+      // 实际上这就是每个用户每次上传照片/留言审核的记录，如果能直接将其在通过审核后记录在数据库里作为一条动态集合，这样前端就不用这么麻烦了
       if (feed.length === 0) {
         feed.push(newBlock);
         continue;
       }
       let lastOne = feed[feed.length-1];
-      if (item.dtype != lastOne.dtype ||
+      const currentTimestamp = new Date(item.create_date).getTime();
+      const lastTimestamp = lastOne ? new Date(lastOne.items[0].create_date).getTime() : null;
+
+      if (!lastOne || 
+          item.dtype != lastOne.dtype ||
           item.cat._id != lastOne.cat._id ||
+          item.user_id != lastOne.items[0].user_id ||
+          lastTimestamp - currentTimestamp > timeInterval ||
           lastOne.items.length >= (lastOne.dtype === 'photo'? 6: 3)) {
         feed.push(newBlock);
       } else {
         lastOne.items.push(item);
       }
+      
     }
     // feed.push(...res);
     this.setData({feed});
@@ -306,13 +436,187 @@ Page({
     wx.navigateTo({
       url: detail_url + '?cat_id=' + cat_id,
     });
+
+    // 关掉弹窗
+    this.closeMenu();
   },
 
   // 打开大图
   clickPhoto(e) {
-    const {url} = e.currentTarget.dataset;
+    const { photoIndex, feedIndex } = e.currentTarget.dataset;
+    console.log(photoIndex, feedIndex);
+    const currentItems = this.data.feed[feedIndex].items;
+
+    const urls = currentItems.map(item => item.pic_prev);
+
     wx.previewImage({
-      urls: [url],
+      urls: urls,
+      current: urls[photoIndex],
     });
+  },
+
+  // 如何引导用户去长按猫猫头像
+  // 点击猫猫头像
+  onCatAvatarTap(e) {
+    const selectedCat = e.currentTarget.dataset.cat;
+    
+    // 对于 #gradient 头像,触发点击事件
+    if (selectedCat.svgImg.includes('url(%23gradient)')) {
+      // 判断是展示某只猫猫的动态，还是全部动态
+      const currentCatId = selectedCat._id === this.data.currentCatId ? null : selectedCat._id;
+      
+      // 更新当前猫猫名字
+      const currentCatName = currentCatId ? selectedCat.name : '';
+
+      // 更新猫猫头像状态
+      const followCatsList = this.data.followCatsList.map(cat => {
+        return this.updateCatAvatarStatus(cat, selectedCat);
+      });
+
+      this.setData({
+        currentCatId,
+        currentCatName,
+        feed: [],
+        loadnomore: false,
+        followCatsList,
+      }, () => {
+        this.resetFeedData();
+      });
+    } else {
+      // 对于 #ccc 头像,不触发点击事件
+      wx.showToast({
+        title: 'ta最近没有新动态哦',
+        icon: 'none',
+      });
+    };
+  },
+
+  // 更新猫猫头像状态 TODO: 添加dasharray过渡动画
+  updateCatAvatarStatus(cat, selectedCat) {
+    const statusMap = {
+      selected: {
+        true: gradientAvatarSvg('url(#gradient)', '5, 15'), // 选中状态
+        false: gradientAvatarSvg('url(#gradient)', '0'),    // 点击另一只猫复原当前状态
+      },
+      unselected: gradientAvatarSvg('url(#gradient)', '0'), // 未选中状态
+    };
+
+    if (cat._id === selectedCat._id) {
+      cat.selected = !cat.selected;
+      cat.svgImg = statusMap.selected[cat.selected];
+    } else if (cat.selected) {
+      cat.selected = false;
+      cat.svgImg = statusMap.unselected;
+    }
+
+    return cat;
+  },
+
+  // 重置动态数据
+  resetFeedData() {
+    this.jsData.waitingList = {
+      photo: [],
+      comment: [],
+    };
+    this.jsData.loadedCount = {
+      photo: 0,
+      comment: 0,
+    };
+    this.loadMoreFeed();
+  },
+
+  closeThisCatFeed() {
+    const currentCatId = this.data.currentCatId;
+    
+    // 更新猫猫头像状态
+    const followCatsList = this.data.followCatsList.map(cat => {
+      if (cat._id === currentCatId) {
+        return this.updateCatAvatarStatus(cat, cat);
+      }
+      return cat;
+    });
+
+    this.setData({
+      currentCatId: null,
+      currentCatName: '',
+      feed: [],
+      loadnomore: false,
+      followCatsList,
+    }, () => {
+      this.resetFeedData();
+    });
+  },
+
+  // 长按猫猫头像
+  onCatAvatarLongPress(e) {
+    const selectedCat = e.currentTarget.dataset.cat;
+    
+    // 触发动画
+    const followCatsList = this.data.followCatsList.map(cat => {
+      if (cat._id === selectedCat._id) {
+        cat.showAnimation = true;
+      }
+      return cat;
+    });
+    this.setData({ followCatsList });
+
+    wx.vibrateShort({ type: 'medium' });
+    
+    this.setData({ 
+      showMenu: true,
+      selectedCat: selectedCat,
+    });
+
+    // 一段时间后隐藏动画
+    setTimeout(() => {
+      const followCatsList = this.data.followCatsList.map(cat => {
+        if (cat._id === selectedCat._id) {
+          cat.showAnimation = false;
+        }
+        return cat;
+      });
+      this.setData({ followCatsList });
+    }, 350);  // 0.35s后隐藏动画
+  },
+  
+  closeMenu() {
+    this.setData({ showMenu: false });
+  },
+
+  async toggleFollowCat(e) {
+    if (this.jsData.updatingFollowCats) {
+      return;
+    }
+
+    this.jsData.updatingFollowCats = true;
+
+    let { unfollowed, catid } = e.currentTarget.dataset;
+    let res = await api.updateFollowCats({
+      updateCmd: unfollowed ? "add" : "del",
+      catId: catid,
+    });
+
+    // 更新取消关注/继续关注按钮的颜色，
+    let newUnfollowedStatus = !this.data.selectedCat.unfollowed;
+    this.setData({
+      'selectedCat.unfollowed': newUnfollowedStatus
+    });
+
+    // 同步更新 followCatsList 中对应的猫的属性
+    let updatedCatsList = this.data.followCatsList.map(catItem => {
+      if (catItem._id === catid) {
+        return { ...catItem, unfollowed: newUnfollowedStatus };
+      }
+      return catItem;
+    });
+    this.setData({
+      followCatsList: updatedCatsList
+    });
+
+    wx.showToast({
+      title: `${unfollowed ? "关注" : "取关"}${res.result ? "成功": "失败"}`,
+      icon: res.result ? "success": "error"
+    });
+    this.jsData.updatingFollowCats = false;
   },
 })

--- a/miniprogram/pages/followFeed/followFeed.json
+++ b/miniprogram/pages/followFeed/followFeed.json
@@ -1,3 +1,6 @@
 {
-  "usingComponents": {}
+  "usingComponents": {
+    "popup": "/components/popup/popup"
+  },
+  "navigationBarTitleText": "喵友圈"
 }

--- a/miniprogram/pages/followFeed/followFeed.wxml
+++ b/miniprogram/pages/followFeed/followFeed.wxml
@@ -2,48 +2,87 @@
 
 <scroll-view id="comment-list" scroll-y="true" bindscrolltolower='loadMoreFeed' enable-back-to-top="true" enable-flex="1" refresher-enabled="{{true}}" refresher-triggered="{{refreshing}}" bindrefresherrefresh="onPullDownRefresh">
 
-  <block wx:for="{{feed}}" wx:key="_id">
-    <view wx:if="{{item.dtype == 'photo'}}" class="photo-block">
-      <view class="cat-info" bind:tap="toCat" data-cat_id='{{item.cat._id}}'>
+  <scroll-view scroll-x="true" enable-flex="true" show-scrollbar="false" enhanced="true" class="story-bar" wx:if="{{followCats && followCats.length > 0}}">
+    <view class="story-container">
+      <block wx:for="{{followCatsList}}" wx:key="_id">
+        <view class="story-item">
+          <view class="cat-avatar-wrapper" bind:tap="onCatAvatarTap" bind:longpress="onCatAvatarLongPress" data-cat="{{item}}">
+            <image class="gradientBorder {{item.showAnimation ? 'scale' : ''}}" src="{{item.svgImg}}"/>
+            <view class="cat-avatar">
+              <view class="scale-avatar {{item.showAnimation ? 'scale' : ''}}">
+                <image class="avatar" src="{{item.avatar.photo_compressed || item.avatar.photo_id}}" mode="aspectFill"/>
+              </view>
+            </view>
+          </view>
+          <text class="cat-name">{{item.name || '-'}}</text>
+        </view>
+      </block>
+    </view>
+  </scroll-view>
+
+  <view class="selected-cat" wx:if="{{currentCatId}}">
+    <view class="cat-name">{{currentCatName}}的动态：</view>
+    <view class="iconfont icon-cross" bind:tap="closeThisCatFeed"></view>
+  </view>
+  
+  <block wx:for="{{feed}}" wx:for-item="feedItem" wx:key="_id" wx:for-index="outerIndex" data-feed-index="{{outerIndex}}">
+    <view wx:if="{{feedItem.dtype == 'photo'}}" class="photo-block">
+      <view class="cat-info" bind:tap="toCat" data-cat_id='{{feedItem.cat._id}}'>
         <view class="cat-avatar">
-          <image class="avatar" src="{{item.cat.avatar.photo_compressed || item.cat.avatar.photo_id}}" mode='aspectFill'></image>
+          <image class="avatar" src="{{feedItem.cat.avatar.photo_compressed || feedItem.cat.avatar.photo_id}}" mode='aspectFill'></image>
         </view>
         <view class="cat-name">
-          <text>{{item.cat.name || '-'}}</text>
-          <text class="cat-campus">[{{item.cat.campus || '-'}}]</text>
+          <text>{{feedItem.cat.name || '-'}}</text>
+          <view class='cat-campus'>
+            <image class="location-logo" src="/pages/public/images/filter/location_gray.png" mode="aspectFit"></image>
+            {{feedItem.cat.campus || '-'}}
+          </view>
         </view>
       </view>
-      <view class="photo" wx:for="{{item.items}}" wx:key="_id">
-        <view class="photo-img" data-url="{{item.pic_prev}}" bind:tap="clickPhoto">
-          <image src="{{item.pic}}" mode='aspectFill'></image>
-        </view>
-        <view class="datetime">{{item.datetime}}</view>
+      <view class="photo-container {{feedItem.items.length === 1 ? 'single-photo' : ''}}" >
+          <!-- 这里可以用上预览图片组件 -->
+          <!-- 该照片是否被用户点赞 -->
+          <view class="photo-img {{feedItem.items.length === 1 ? 'single-photo' : ''}}" 
+            wx:for="{{feedItem.items}}" 
+            wx:key="_id" 
+            wx:for-index="innerIndex" 
+            data-photo-index="{{innerIndex}}" 
+            data-feed-index="{{outerIndex}}" 
+            data-url="{{item.pic_prev}}"
+            bind:tap="clickPhoto">
+            <image src="{{item.pic}}" mode='aspectFill'></image>
+          </view>
+      </view>
+      <view class="photo-by">
         <view class="user-info">
           <view class="user-avatar">
-            <image wx:if="{{item.userInfo}}" class="avatar" src="{{item.userInfo.avatarUrl}}" mode='aspectFit'></image>
-            <image wx:else class="avatar" src="/pages/public/images/app_logo.png" mode='aspectFit'></image>
+            <image wx:if="{{feedItem.items[0].userInfo}}" src="{{feedItem.items[0].userInfo.avatarUrl}}" mode="aspectFit"></image>
+            <image wx:else class="avatar" src="/pages/public/images/app_logo.png" mode="aspectFit"></image>
           </view>
-          <view class="username">
-            {{item.userInfo.nickName || '-'}}
-          </view>
+          <view class="username">{{feedItem.items[0].userInfo ? feedItem.items[0].userInfo.nickName : '-'}}</view>
         </view>
+        <view class="dot"></view>
+        <view class="datetime">{{feedItem.items[0].datetime}}</view>
       </view>
 
     </view>
 
     <!-- 留言组 -->
-    <view class="comment-block" wx:if="{{item.dtype == 'comment'}}">
+    <view class="comment-block" wx:if="{{feedItem.dtype == 'comment'}}">
       
-      <view class="cat-info" bind:tap="toCat" data-cat_id='{{item.cat._id}}'>
+      <view class="cat-info" bind:tap="toCat" data-cat_id='{{feedItem.cat._id}}'>
         <view class="cat-avatar">
-          <image class="avatar" src="{{item.cat.avatar.photo_compressed || item.cat.avatar.photo_id}}" mode='aspectFill'></image>
+          <image class="avatar" src="{{feedItem.cat.avatar.photo_compressed || feedItem.cat.avatar.photo_id}}" mode='aspectFill'></image>
         </view>
         <view class="cat-name">
-          <text>{{item.cat.name || '-'}}</text>
-          <text class="cat-campus">[{{item.cat.campus || '-'}}]</text>
+          <text>{{feedItem.cat.name || '-'}}</text>
+          <view class='cat-campus'>
+            <image class="location-logo" src="/pages/public/images/filter/location_gray.png" mode="aspectFit"></image>
+            {{feedItem.cat.campus || '-'}}
+          </view>
         </view>
       </view>
-    <view wx:for="{{item.items}}" wx:key="_id" class="comment {{item.paper_color}} {{item.needVerify? 'need-verify': ''}}" style="transform: rotate({{item.rotate || 0}}deg);">
+    <view wx:for="{{feedItem.items}}" wx:key="_id" class="comment {{item.paper_color}} {{item.needVerify? 'need-verify': ''}}" style="transform: rotate({{item.rotate || 0}}deg);">
       <view class="wavy-line"></view>
       <view class="paper">
         <view class="user-info">
@@ -73,7 +112,7 @@
   </block>
 
   <!-- 没有关注 -->
-  <view class="noFollow" wx:if="{{!followCats || followCats.length === 0}}">
+  <view class="noFollow" wx:if="{{loadnomore && (!followCats || followCats.length === 0)}}">
     <view><text>你没有关注任何猫猫\n快到猫猫详情页去添加吧~</text></view>
     <image class="icon" src='/pages/public/images/button/plus.svg'></image>
     <image class="icon" src='/pages/public/images/button/follow.svg'></image>
@@ -89,4 +128,23 @@
     <image src='/pages/public/images/system/loading.gif'></image>
   </view>
 
+  
 </scroll-view>
+
+<popup show="{{showMenu}}" bind:close="closeMenu">
+  <view class="menu-container">
+    <view class="menu-item">
+      <view class="cat-avatar-wrapper">
+        <view class="cat-avatar">
+          <image class="avatar" src="{{selectedCat.avatar.photo_compressed || selectedCat.avatar.photo_id}}" mode="aspectFill"/>
+        </view>
+      </view>
+      <view class="cat-name">{{selectedCat.name || '-'}}</view>
+    </view>
+    <view class="menu-item" bind:tap="toCat" data-cat_id="{{selectedCat._id}}">查看主页</view>
+    <view class="menu-item follow-btn {{selectedCat.unfollowed ? 'unfollowed' : 'followed'}}" bind:tap="toggleFollowCat" data-catid="{{selectedCat._id}}" data-unfollowed="{{selectedCat.unfollowed}}">
+      {{selectedCat.unfollowed ? "继续关注" : "取消关注"}}
+    </view>
+    <view class="menu-item" bind:tap="closeMenu">关闭</view>
+  </view>
+</popup>

--- a/miniprogram/pages/followFeed/followFeed.wxss
+++ b/miniprogram/pages/followFeed/followFeed.wxss
@@ -156,7 +156,7 @@ image{height:auto}
   width: 100%;
   text-align: center;
   color: var(--color-gray-max);
-  top: 50%;
+  top: calc(50% - 100rpx);
   transform: translateY(-50%);
   position: absolute;
 }

--- a/miniprogram/pages/followFeed/followFeed.wxss
+++ b/miniprogram/pages/followFeed/followFeed.wxss
@@ -1,28 +1,34 @@
 /* pages/followFeed/followFeed.wxss */
-@import "/pages/public/wxss/hFilter.wxss";
+@import "../public/wxss/hFilter.wxss";
 @import '../genealogy/commentBoard/commentBoard.wxss';
 
+/* 去掉滚动条 */
+::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+  color: transparent;
+}
+
+image{height:auto}
 
 #comment-list {
   width: 750rpx;
   height: 100%;
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
+  align-items: flex-start;
+  position: relative;
 }
 
 /* 一组照片 */
 .photo-block, .comment-block {
   width: 100%;
-  margin: 15rpx 30rpx 0rpx 30rpx;
   box-sizing: border-box;
   display: flex;
-  flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-evenly;
-  padding-bottom: 15rpx;
-  border-bottom: 1rpx solid var(--color-gray-normal);
+  justify-content: center;
+  padding: 30rpx 30rpx 20rpx 30rpx;
+  border-top: 1rpx solid var(--color-gray);
 }
 
 .cat-info {
@@ -31,22 +37,22 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-bottom: 10rpx;
 }
 
-.cat-info.right {
-  justify-content: flex-end;
-}
-
-.cat-avatar {
-  margin-left: 20rpx;
+.cat-info .cat-avatar {
   width: 60rpx;
   height: 60rpx;
 }
-.photo-img image, .cat-avatar image, .user-info image {
+
+.photo-img image, .cat-avatar image {
   width: 100%;
   height: 100%;
 }
+.cat-avatar image {
+  border-radius: 50%;
+  background-color: var(--color-gray);
+}
+
 .cat-info .cat-name {
   font-size: 28rpx;
   color: var(--color-black-light);
@@ -57,56 +63,102 @@
 .cat-info .cat-campus {
   font-size: 18rpx;
   color: var(--color-gray-dark);
+  align-items: center;
+  display: flex;
 }
+.location-logo {
+  width: 24rpx;
+  height: 24rpx;
+  margin-right: 4rpx;
+}
+
 /* 照片卡 */
-.photo {
-  width: 30%;
-  background-color: white;
-  border-radius: 20rpx;
-  overflow: hidden;
-  margin: 10rpx 0;
-  padding-bottom: 10rpx;
+.photo-container {
+  width: 100%;
+  display: grid;
+  gap: 10rpx;
+  padding: 15rpx 0;
+  grid-template-columns: 1fr 1fr 1fr;
+  transition: all 0.4s ease;
+  animation: fadeIn 0.5s; /* 图片渲染慢，动画过渡一下 */
+}
+.photo-block .single-photo {
+  grid-template-columns: 1fr;  /* 单张图片时全宽度 */
 }
 
 .photo-img {
-  width: 240rpx;
-  height: 240rpx;
-}
+  /* 令高等于宽度 */
+  height: 0;
+  padding-bottom: 100%;
+  position: relative;
 
-.photo .datetime {
   width: 100%;
-  text-align: center;
+  border-radius: 15rpx;
+  overflow: hidden;
+  background-color: white;
+  background-image: var(--img-default);
+  background-size: 60% 60%;
+  background-repeat: no-repeat;
+  background-position: center center;
+  transition: all 0.4s ease;
+}
+.photo-container .single-photo {
+  padding-bottom: 75%;
+}
+.photo-img image {
+  /* 令高等于宽 */
+  position: absolute;
 }
 
-.user-info {
+.photo-by {
   width: 100%;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  align-content: flex-start;
 }
 
-.user-info .user-avatar {
-  margin-left: 20rpx;
-  width: 40rpx;
-  height: 40rpx;
+.photo-block .datetime {
+  text-align: left;
+  width: auto;
+  font-size: 24rpx;
+  margin-left: 10rpx;
+  margin-bottom: 10rpx;
 }
 
-.user-info .username {
-  width: 60%;
-  height: 40rpx;
-  font-size: 20rpx;
-  line-height: 40rpx;
+.dot {
+  width: 6rpx;
+  height: 6rpx;
+  background-color: var(--color-black-min);
+  border-radius: 50%;
+  margin-bottom: 10rpx;
+}
+
+.photo-block .user-info {
+  width: auto;
+  align-items: center;
+  border-radius: 50rpx;
+  margin-block-end: 10rpx;
+}
+
+.photo-block .username {
+  /* width: 100%; */
+  font-size: 24rpx;
+  margin: 0 10rpx;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  color: var(--color-black-min);
 }
-
-
 
 /* 未关注提醒 */
 .noFollow {
   width: 100%;
   text-align: center;
   color: var(--color-gray-max);
+  top: 50%;
+  transform: translateY(-50%);
+  position: absolute;
 }
 
 .noFollow image {
@@ -129,4 +181,169 @@
   font-size: 24rpx;
   text-align: center;
   color: var(--color-gray-dark);
+}
+
+/* 顶部导航 */
+.menu-item, .story-item  {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.story-bar {
+  padding-bottom: 10rpx;
+}
+
+.story-container {
+  display: inline-flex;
+  margin: 30rpx 15rpx 0 15rpx;
+}
+
+.story-item {
+  margin: 0 15rpx 0 15rpx;
+  box-sizing: border-box;
+}
+
+.story-item .cat-avatar-wrapper {
+  width: 170rpx;
+  height: 170rpx;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.cat-avatar-wrapper .gradientBorder{
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  transition: transform 0.2s linear;
+}
+
+.cat-avatar-wrapper .gradientBorder.scale {
+  transform: scale(1.02);
+}
+
+.story-item .cat-avatar {
+  /* cat-avatar-wrapper的宽高减去两倍边框宽度 */
+  width: 146rpx;
+  height: 146rpx;
+  border-radius: 50%;
+  animation: fadeIn 0.5s; /* 图片渲染慢，动画过渡一下 */
+}
+
+.story-item .cat-avatar .scale-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--color-gray);
+  transition: transform 0.2s linear;
+}
+
+.story-item .cat-avatar .scale-avatar.scale {
+  transform: scale(0.92);
+}
+
+.story-item .cat-name {
+  width: 100%;
+  font-size: 24rpx;
+  margin-top: 10rpx;
+  color: var(--color-black-light);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.selected-cat {
+  width: 100%;
+  padding: 10rpx 30rpx;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: fadeIn 0.3s;
+}
+
+.selected-cat .cat-name {
+  display: inline-block;
+  font-size: 28rpx;
+  font-weight: 700;
+}
+.iconfont {
+  color: var(--color-gray-max);
+  animation: rotate 0.3s ease;
+}
+
+/* 菜单 */
+.menu-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+.menu-item {
+  width: 100%;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  margin: 30rpx 0;
+}
+
+.menu-item:first-child {
+  margin-bottom: 0;
+  padding-bottom: 30rpx;
+  border-bottom: 1rpx solid var(--color-gray);
+}
+
+.menu-item .cat-avatar-wrapper {
+  width: 120rpx;
+  height: 120rpx;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.menu-item .cat-avatar {
+  width: 100%;
+  height: 100%;
+}
+
+.menu-item .cat-name {
+  width: 100%;
+  font-size: 24rpx;
+  font-weight: 700; /* 粗体：ios真机上无效 */
+  margin-top: 20rpx;
+  color: var(--color-black-light);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.follow-btn.unfollowed {
+  color: #FF0000;
+}
+
+.follow-btn.followed {
+  color: var(--color-gray-dark);
+}
+
+/* 动画 */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(90deg);
+  }
 }

--- a/miniprogram/pages/followFeed/gradientAvatar.svg.js
+++ b/miniprogram/pages/followFeed/gradientAvatar.svg.js
@@ -1,0 +1,15 @@
+export const gradientAvatarSvg = (color = '#ccc', dashArray = '0') => {
+  // 在网站 https://colorkit.co/gradients/ 生成渐变色代码
+  const svgXml = `<svg xmlns="http://www.w3.org/2000/svg" class="gradientAvatar" width="170" height="170">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#fd5" />
+      <stop offset="10%" stop-color="#fd5" />
+      <stop offset="50%" stop-color="#ff543e" />
+      <stop offset="100%" stop-color="#c837ab" />
+    </linearGradient>
+  </defs>
+  <circle cx="85" cy="85" r="82" fill="none" stroke="${color}" stroke-width="6" stroke-dasharray="${dashArray}" stroke-linecap="round"/>
+</svg>`;
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgXml)}`;
+};

--- a/miniprogram/pages/genealogy/commentBoard/commentBoard.wxss
+++ b/miniprogram/pages/genealogy/commentBoard/commentBoard.wxss
@@ -21,6 +21,7 @@ page {
     -webkit-linear-gradient(top, white 38rpx, var(--color-gray) 40rpx);
   background-size: 100% 40rpx;
   position: relative;
+  filter: drop-shadow(0rpx 12rpx 10rpx var(--color-ltblack-transparent));
 }
 
 .comment .tape {
@@ -64,6 +65,16 @@ page {
   flex-direction: row;
   align-items: center;
   box-sizing: border-box;
+}
+.user-info .user-avatar {
+  width: 40rpx;
+  height: 40rpx;
+}
+.user-info image {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: white;
 }
 
 .username {

--- a/miniprogram/pages/info/info.wxss
+++ b/miniprogram/pages/info/info.wxss
@@ -84,7 +84,7 @@ page {
 .mina-info image {
   width: 150rpx;
   height: 150rpx;
-  border-radius: 20rpx;
+  border-radius: 75rpx;
   box-shadow: 0 0 10rpx var(--color-gray);
 }
 
@@ -175,20 +175,20 @@ page {
 .badge {
   position: absolute;
   text-align: center;
-  top: 25rpx;
-  right: 70rpx;
+  top: 20rpx;
+  left: 120rpx;
   min-width: 26rpx;
   height: 26rpx;
   line-height: 26rpx;
-  border-radius: 100%;
+  border-radius: 26rpx;
   background-color: red;
   color: white;
-  font-size: 19rpx;
+  font-size: 22rpx;
   font-weight: bold;
   overflow: hidden;
   white-space: nowrap;
-  border: 3rpx solid white;
-  padding: 4rpx
+  border: 4rpx solid white;
+  padding: 4rpx;
 }
 
 .dot {

--- a/miniprogram/pages/info/myFollowCats/myFollowCats.wxml
+++ b/miniprogram/pages/info/myFollowCats/myFollowCats.wxml
@@ -3,11 +3,19 @@
 
 <view class="follow-count">共关注{{followCount || 0}}只猫猫</view>
 
-<view class="card" wx:for="{{followCats}}" wx:key="_id">
-  <view class="avatar">
+<view class="cat-info-container">
+<view class="cat-info" wx:for="{{followCats}}" wx:key="_id">
+  <view class="cat-avatar">
     <image src="{{item.avatar.photo_compressed || item.avatar.photo_id}}" mode="aspectFill"/>
   </view>
-  <view class="name">{{item.name}}<text class="campus"> [{{item.campus}}]</text></view>
+  <view class="cat-name">
+    <text>{{item.name || '-'}}</text>
+    <view class='cat-campus'>
+      <image class="location-logo" src="/pages/public/images/filter/location_gray.png" mode="aspectFit"></image>
+      {{item.campus || '-'}}
+    </view>
+  </view>
   
-  <button class="primary" bind:tap="doFollowCat" data-index="{{index}}" data-catid="{{item._id}}" data-unfollowed="{{item.unfollowed}}">{{item.unfollowed ? '继续关注' : '取消关注'}}</button>
+  <view class="follow-btn {{item.unfollowed ? 'unfollowed' : 'followed'}}" bind:tap="doFollowCat" data-index="{{index}}" data-catid="{{item._id}}" data-unfollowed="{{item.unfollowed}}">{{item.unfollowed ? '继续关注' : '取消关注'}}</view>
+</view>
 </view>

--- a/miniprogram/pages/info/myFollowCats/myFollowCats.wxss
+++ b/miniprogram/pages/info/myFollowCats/myFollowCats.wxss
@@ -1,45 +1,78 @@
 /* pages/info/myFollowCats/myFollowCats.wxss */
+page {
+  background-color: var(--color-gray-light);
+}
 
 .follow-count {
-  width: 750rpx;
+  width: 100%;
   text-align: center;
   color: var(--color-black-light);
   margin-top: 30rpx;
 }
 
-.card {
-  width: 750rpx;
+.cat-info {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 20rpx 0;
+  justify-content: space-between;
+  /* margin: 20rpx 0; */
   padding: 20rpx 30rpx;
-  border-bottom: 1rpx solid var(--color-gray-light);
+  border-bottom: 1rpx solid var(--color-gray);
 }
 
+.cat-info-container .cat-info:last-child {
+  border-bottom: none;
+}
 
-.avatar {
+.cat-avatar {
   width: 100rpx;
   height: 100rpx;
+  border-radius: 50%;
+  overflow: hidden;
 }
 
-.avatar image {
+.cat-avatar image {
   width: 100%;
   height: 100%;
+  background-color: var(--color-gray);
 }
 
-.name {
-  font-size: 30rpx;
-  width: 300rpx;
-  /* background-color: aqua; */
-  padding: 0 30rpx;
+.cat-name {
+  font-size: 28rpx;
+  color: var(--color-black-light);
+  margin-left: 15rpx;
+  display: flex;
+  flex-direction: column;
 }
-
-.campus {
+.cat-campus {
   font-size: 24rpx;
+  color: var(--color-gray-dark);
+  align-items: center;
+  display: flex;
+}
+.location-logo {
+  width: 24rpx;
+  height: 24rpx;
+  margin-right: 4rpx;
+}
+
+.follow-btn {
+  border-radius: 25rpx;
+  height: 50rpx;
+  font-size: 24rpx;
+  padding: 0rpx 20rpx;
+  margin-left: auto;
+  display: flex;
+  text-align: center;
+  align-items: center;
+}
+
+.followed {
+  border: 3rpx solid var(--color-gray-dark);
   color: var(--color-gray-dark);
 }
 
-button {
-  font-size: 26rpx;
+.unfollowed {
+  border: 2rpx solid var(--color-primary);
+  color: var(--color-primary);
 }


### PR DESCRIPTION
- 添加顶部关注列表导航栏，可以轻松查看某只猫猫的动态，长按头像在弹出菜单进行关注-取关操作；
- 优化动态照片布局，使用`display: grid`指定列数布局的方式（若动态为单张照片时为1列）；
- 调整了datetime时间的格式；
- 对新增一个block的条件进行细化，每条动态更加精准；
- 调整popup组件的z-index属性，使之能够覆盖tabbar；
- 调整了用户关注列表ui；
- 另外，调整了关于页管理后台待处理任务数量的数字提示样式；